### PR TITLE
Feature/verify page 버튼 기능 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@typescript-eslint/eslint-plugin": "^7.13.1",
         "@typescript-eslint/parser": "^7.13.1",
         "axios": "^1.8.4",
+        "lucide-react": "^0.510.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
@@ -4258,6 +4259,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.510.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.510.0.tgz",
+      "integrity": "sha512-p8SQRAMVh7NhsAIETokSqDrc5CHnDLbV29mMnzaXx+Vc/hnqQzwI2r0FMWCcoTXnbw2KEjy48xwpGdEL+ck06Q==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
     "axios": "^1.8.4",
+    "lucide-react": "^0.510.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",

--- a/frontend/src/pages/VerifyPage/components/EditConfirmButtons.tsx
+++ b/frontend/src/pages/VerifyPage/components/EditConfirmButtons.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import {Edit, FileCheck} from 'lucide-react'; 
+
+ interface Props {
+   onEdit: () => void;
+   onConfirm: () => void;
+   confirmDisabled: boolean; // ‘확인’ 버튼의 활성/비활성 여부
+   className?: string;
+ }
+
+ const EditConfirmButtons: React.FC<Props> = ({
+   onEdit,
+   onConfirm,
+   confirmDisabled,
+ }) => (
+   <div className="fixed bottom-[17rem] right-[14rem] flex flex-col gap-4">
+     <button
+       onClick={onEdit}
+       className="w-12 h-12 rounded-full bg-mainGreen text-white flex items-center justify-center"
+     >
+       <Edit />    {/* 수정 아이콘 */}
+     </button>
+     <button
+        onClick={onConfirm}
+        disabled={confirmDisabled}
+        className="w-12 h-12 rounded-full bg-mainGreen text-white flex items-center justify-center disabled:opacity-50"
+     >
+       <FileCheck />  {/* 확인 아이콘 */}
+     </button>
+   </div>
+ );
+ export default EditConfirmButtons;

--- a/frontend/src/pages/VerifyPage/components/InfoRow.tsx
+++ b/frontend/src/pages/VerifyPage/components/InfoRow.tsx
@@ -55,7 +55,7 @@ const InfoRow: React.FC<Props> = ({
           border rounded-lg bg-white text-left text-base
         ${inputClassName} 
         `}
-        value={value}
+        defaultValue={value}
         readOnly={readOnly}
       />
       {suffix && <span className="ml-2">{suffix}</span>}

--- a/frontend/src/pages/VerifyPage/components/SectionHeader.tsx
+++ b/frontend/src/pages/VerifyPage/components/SectionHeader.tsx
@@ -7,11 +7,11 @@ interface Props {
 // 이 컴포넌트에는 반드시 (문자열 형식의) title  을 전달해야함
 
 /**
- * 화면의 각 섹션(예: 기초 지수, 최대손실 성립 조건 %) 제목 + 녹색 밑줄을 그리는 컴포넌트
+ 화면의 각 섹션(예: 기초 지수, 최대손실 성립 조건 %) 제목 + 녹색 밑줄을 그리는 컴포넌트
  */
 const SectionHeader: React.FC<Props> = ({ title }) => (
   <div className="mb-4 flex flex-col">
-    <h2 className="text-[20px] font-bold">{title}</h2>
+    <h2 className="text-[18px] font-bold">{title}</h2>
     
     <div className="w-full h-[2px] bg-mainGreen mt-1" />
   </div>

--- a/frontend/src/pages/VerifyPage/index.tsx
+++ b/frontend/src/pages/VerifyPage/index.tsx
@@ -1,10 +1,3 @@
-// const VerifyPage = () => {
-//   return <div>값 확인 페이지</div>;
-// };
-
-// export default VerifyPage;
-
-
 
 // src/pages/VerifyPage/index.tsx
 import React from 'react';
@@ -19,7 +12,7 @@ const VerifyPage: React.FC = () => {
   if (isError || !data) return <div className="p-8">데이터를 불러오는 중 오류가 발생했습니다.</div>;
 
   return (
-    <div className="p-8 grid grid-cols-3 gap-6">
+    <div className="p-8 grid grid-cols-[repeat(3,minmax(240px,1fr))]  gap-6">
       
       {/* 1열: 기초 지수 */}
       <div>

--- a/frontend/src/pages/VerifyPage/index.tsx
+++ b/frontend/src/pages/VerifyPage/index.tsx
@@ -1,18 +1,33 @@
 
 // src/pages/VerifyPage/index.tsx
-import React from 'react';
+import React, {useState} from 'react';
 import SectionHeader from './components/SectionHeader';
 import InfoRow from './components/InfoRow';
 import useVerifyData from './hooks/useVerifyData';
+import EditConfirmButtons from './components/EditConfirmButtons';
+
 
 const VerifyPage: React.FC = () => {
+  // 데이터 로딩 훅
   const { data, isLoading, isError } = useVerifyData();
+  // ‘수정 모드’ 상태 추가
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleEdit = () => {
+    setIsEditing(true);
+  };
+
+  const handleConfirm = () => {
+    // TODO: 실제 저장 로직 수행
+    setIsEditing(false);
+  };
 
   if (isLoading) return <div className="p-8">로딩 중…</div>;
   if (isError || !data) return <div className="p-8">데이터를 불러오는 중 오류가 발생했습니다.</div>;
 
   return (
-    <div className="p-8 grid grid-cols-[repeat(3,minmax(240px,1fr))]  gap-6">
+    <div className="relative p-8 max-w-[1200px] mx-auto">
+    <div className="grid grid-cols-[repeat(3,minmax(240px,1fr))]  gap-6">
       
       {/* 1열: 기초 지수 */}
       <div>
@@ -31,17 +46,17 @@ const VerifyPage: React.FC = () => {
           label="만기일 가격"
           value={data.maxLossPrice.toString()} 
           suffix="%" 
-          readOnly
+          readOnly={!isEditing}
           inputClassName='w-32' /* 128 px */
         />
-        <InfoRow label="낙인 구간"   value={data.knockInRatio.toString()}   suffix="%" readOnly
+        <InfoRow label="낙인 구간"   value={data.knockInRatio.toString()}   suffix="%" readOnly={!isEditing}
         inputClassName='w-32' />
       </div>
 
       {/* 3열: 만기평가일 및 만기일 */}
       <div>
         <SectionHeader title="만기평가일 및 만기일" />
-        <InfoRow label="만기평가일" value={data.evaluationDate} readOnly
+        <InfoRow label="만기평가일" value={data.evaluationDate} readOnly={!isEditing}
         inputClassName='w-48' /> {/* 192 px */}
         <InfoRow label="만기일"     value={data.maturityDate}  readOnly
         inputClassName='w-48' plainText />
@@ -51,7 +66,7 @@ const VerifyPage: React.FC = () => {
       <div>
         <SectionHeader title="자동조기상환평가일" />
         {data.earlyRedeemDates.map((date, i) => (
-          <InfoRow key={i} label={`${i + 1}차`} value={date} readOnly
+          <InfoRow key={i} label={`${i + 1}차`} value={date} readOnly={!isEditing}
           inputClassName='w-48'
           />
         ))}
@@ -61,7 +76,7 @@ const VerifyPage: React.FC = () => {
       <div>
         <SectionHeader title="자동조기상환 성립 조건 (% 이상)" />
         {data.earlyRedeemConditions.map((c, i) => (
-          <InfoRow key={i} label={`${i + 1}차`} value={c.toString()} suffix="%" readOnly
+          <InfoRow key={i} label={`${i + 1}차`} value={c.toString()} suffix="%" readOnly={!isEditing}
           inputClassName='w-32' />
         ))}
       </div>
@@ -70,10 +85,19 @@ const VerifyPage: React.FC = () => {
       <div>
         <SectionHeader title="자동조기상환 수익률" />
         {data.earlyRedeemYields.map((y, i) => (
-          <InfoRow key={i} label={`${i + 1}차`} value={y.toString()} suffix="%" readOnly
+          <InfoRow key={i} label={`${i + 1}차`} value={y.toString()} suffix="%" readOnly={!isEditing}
           inputClassName='w-28' prefix="액면금액 x"/>
         ))}
       </div>
+      {/* 수정/확인 버튼 */}
+      <EditConfirmButtons
+        className="absolute top-[17rem] right-8"
+        onEdit={handleEdit}
+        onConfirm={handleConfirm}
+        confirmDisabled={!isEditing}  // 수정 모드가 아닐 땐 확인 비활성화
+      />
+
+    </div>
     </div>
   );
 };


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 버튼 구현 완료

## 📝 요구 사항과 구현 내용
- 연필 이모지의 '수정' 버튼을 누르면, input 칸이 수정될 수 있도록 바뀌고 동시에 문서 이모지의 '확인' 버튼 또한 활성화됩니다.
- 수정이 끝나고 '확인' 버튼을 누르면 됩니다.
- 
## 💬 PR 포인트 & 궁금한 점
 -> 수정된 값이 다름 페이지로 연동되도록 추후 개선해야함
-버튼 위치가 창 크기 변화에 따라 다른 요소들과 겹치게 됨. 디자인 또한 개선해야함

## 🔗 연관된 이슈
