### PR TITLE
💄 Design : 수익구조, 만기 상환 차트 디자인 수정

### DIFF
--- a/frontend/src/pages/Dashboard/components/IndexChartButton.tsx
+++ b/frontend/src/pages/Dashboard/components/IndexChartButton.tsx
@@ -9,7 +9,7 @@ const IndexChartButton = ({
 }) => {
   return (
     <button
-      className={`text-xs bg-grayBackground px-2 py-1 rounded-[5px] cursor-pointer ${active === value ? 'bg-mainGreen' : ''}`}
+      className={`text-xs bg-grayBackground px-2 py-1 rounded-[5px] cursor-pointer duration-100 ease-linear transition ${active === value ? 'bg-mainGreen' : ''}`}
       name={value}
       onClick={onClickFunction}
     >

--- a/frontend/src/pages/Dashboard/components/RepaymentScenario.tsx
+++ b/frontend/src/pages/Dashboard/components/RepaymentScenario.tsx
@@ -14,8 +14,6 @@ import {
 import { getFileValue } from '../../../utils/savedFile';
 import { PdfValue, RoundKey } from '../../../typings/types';
 
-
-
 // // 더미 기준치 (예: 낙인구간)
 // // 실제 데이터가 없으니 예시로 50% 고정
 // const knockInRatio = 50;
@@ -30,13 +28,14 @@ import { PdfValue, RoundKey } from '../../../typings/types';
 //   { period: '만기',         early: knockInRatio, maturity: knockInRatio + 5 },
 // ];
 
-
-const RepaymentScenario: React.FC<{ onOpenModal?: () => void }> = ({ onOpenModal }) => {
+const RepaymentScenario: React.FC<{ onOpenModal?: () => void }> = ({
+  onOpenModal,
+}) => {
   const file = getFileValue() as PdfValue | null;
   if (!file) {
     return (
-      <DashboardItem title="만기 상환 시나리오">
-        <div className="text-center text-gray-500">데이터가 없습니다.</div>
+      <DashboardItem title='만기 상환 시나리오'>
+        <div className='text-center text-gray-500'>데이터가 없습니다.</div>
       </DashboardItem>
     );
   }
@@ -47,23 +46,23 @@ const RepaymentScenario: React.FC<{ onOpenModal?: () => void }> = ({ onOpenModal
   // const entries = (['1차', '2차', '3차', '4차', '5차'] as RoundKey[]).map(
   //   (key) => ({
 
-
   //     period: `${key} 조기상환`,
   //     early: file.자동조기상환[key].자동조기상환성립조건,
   //     maturity: file.자동조기상환[key].자동조기상환성립조건 - 5,
   //   })
   // );
- const entries = (['1차', '2차', '3차', '4차', '5차'] as RoundKey[]).map((key) => {
-    const rawEarly = file.자동조기상환[key].자동조기상환성립조건;
-    // rawEarly가 문자열일 수 있으므로 Number()로 감싸서 숫자로 변환
-    const earlyNum = Number(rawEarly);
-    return {
-      period: `${key} 조기상환`,
-      early: earlyNum,
-      maturity: earlyNum - 5,  // 숫자(earlyNum) - 5
-    };
-  });
-
+  const entries = (['1차', '2차', '3차', '4차', '5차'] as RoundKey[]).map(
+    (key) => {
+      const rawEarly = file.자동조기상환[key].자동조기상환성립조건;
+      // rawEarly가 문자열일 수 있으므로 Number()로 감싸서 숫자로 변환
+      const earlyNum = Number(rawEarly);
+      return {
+        period: `${key} 조기상환`,
+        early: earlyNum,
+        maturity: earlyNum - 5, // 숫자(earlyNum) - 5
+      };
+    },
+  );
 
   // 마지막 만기 포인트 추가
   entries.push({
@@ -75,36 +74,35 @@ const RepaymentScenario: React.FC<{ onOpenModal?: () => void }> = ({ onOpenModal
   console.log('▶ RepaymentScenario entries:', entries);
 
   return (
-    <DashboardItem title="만기 상환 시나리오">
-
-      <div className="flex flex-col h-full">
-        {/* 차트 영역 (높이 200px, flex-1) */}
-        <div className="flex-1">
-          <ResponsiveContainer width="100%" height={250}>
-            <LineChart data={entries} margin={{ top: 10, right: 10, bottom: 10, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="period" />
-              <YAxis domain={[50, 'dataMax']} unit="%" />
+    <DashboardItem title='만기 상환 시나리오'>
+      <div className='flex flex-col h-full'>
+        {/* 차트 영역 (flex-1) */}
+        <div className='flex-1 min-h-0'>
+          <ResponsiveContainer width='100%' height='100%'>
+            <LineChart
+              data={entries}
+              margin={{ top: 10, right: 10, bottom: 10, left: 0 }}
+            >
+              <CartesianGrid strokeDasharray='3 3' />
+              <XAxis dataKey='period' />
+              <YAxis domain={[50, 'dataMax']} unit='%' />
 
               <Tooltip formatter={(val: number) => `${val.toFixed(2)}%`} />
-                
-              <Legend 
-                verticalAlign="top"
-                wrapperStyle={{ top: 0, left: 0 }} 
-                />
+
+              <Legend verticalAlign='top' wrapperStyle={{ top: 0, left: 0 }} />
               <Line
-                type="monotone"
-                dataKey="early"
-                name="조기상환 충족 조건"
-                stroke="#000000"
+                type='monotone'
+                dataKey='early'
+                name='조기상환 충족 조건'
+                stroke='#000000'
                 dot={{ r: 4 }}
                 activeDot={{ r: 6 }}
               />
               <Line
-                type="monotone"
-                dataKey="maturity"
-                name="만기상환 되는 경우"
-                stroke="#FF0000"
+                type='monotone'
+                dataKey='maturity'
+                name='만기상환 되는 경우'
+                stroke='#FF0000'
                 dot={{ r: 4 }}
                 activeDot={{ r: 6 }}
               />
@@ -116,7 +114,7 @@ const RepaymentScenario: React.FC<{ onOpenModal?: () => void }> = ({ onOpenModal
         {onOpenModal && (
           <button
             onClick={onOpenModal}
-            className="mt-2 px-4 py-2 bg-mainGreen text-white rounded-md self-center"
+            className='h-9 p-2 w-full text-sm bg-grayBackground rounded-md hover:bg-mainGreen hover:text-white duration-100 ease-linear transition'
           >
             📈 크게 보기
           </button>

--- a/frontend/src/pages/Dashboard/components/RevenueStructure.tsx
+++ b/frontend/src/pages/Dashboard/components/RevenueStructure.tsx
@@ -14,8 +14,6 @@ import {
 import { getFileValue } from '../../../utils/savedFile';
 import { PdfValue, RoundKey } from '../../../typings/types';
 
-
-
 // // 예시 5개 조기상환 수익률 더미 데이터 (수익구조 분석 차트)
 // const dummyRevenueData = [
 //   { period: '1차 조기상환', yield: 104.65 },
@@ -25,13 +23,14 @@ import { PdfValue, RoundKey } from '../../../typings/types';
 //   { period: '5차상환', yield: 123.25 },
 // ];
 
-
-const RevenueStructure: React.FC<{ onOpenModal?: () => void }> = ({ onOpenModal }) => {
+const RevenueStructure: React.FC<{ onOpenModal?: () => void }> = ({
+  onOpenModal,
+}) => {
   const file = getFileValue() as PdfValue | null;
-  if (!file) { 
+  if (!file) {
     return (
-      <DashboardItem title="수익구조 분석 차트">
-        <div className="text-center text-gray-500">데이터가 없습니다.</div>
+      <DashboardItem title='수익구조 분석 차트'>
+        <div className='text-center text-gray-500'>데이터가 없습니다.</div>
       </DashboardItem>
     );
   }
@@ -41,42 +40,35 @@ const RevenueStructure: React.FC<{ onOpenModal?: () => void }> = ({ onOpenModal 
     (key) => ({
       period: `${key} 조기상환`,
       yield: file.자동조기상환[key].자동조기상환수익률,
-    })
+    }),
   );
 
-
-
   return (
-    <DashboardItem title="수익구조 분석 차트">
-
+    <DashboardItem title='수익구조 분석 차트'>
       {/*
         main 영역이 곧 children 위치이므로,
         여기서부터 flex flex-col h-full 구조를 줘서
         "차트 영역" + "버튼" 을 쌓는다.
       */}
-      <div className="flex flex-col h-full">
+      <div className='flex flex-col h-full'>
         {/* 1) 차트: 높이를 200px로 줄이고, flex-1을 줘서 남은 공간을 최대한 채우도록 */}
-        <div className="flex-1">
-          <ResponsiveContainer width="100%" height={250}>
+        <div className='flex-1 min-h-0'>
+          <ResponsiveContainer width='100%' height='100%'>
             <LineChart
               data={data}
               margin={{ top: 10, right: 10, bottom: 10, left: 0 }}
             >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="period" />
-              <YAxis domain={[50, 'dataMax']} unit="%" />
+              <CartesianGrid strokeDasharray='3 3' />
+              <XAxis dataKey='period' />
+              <YAxis domain={[50, 'dataMax']} unit='%' />
               <Tooltip formatter={(val: number) => `${val.toFixed(2)}%`} />
-              <Legend 
-                verticalAlign="top"
-                  wrapperStyle={{ top: 0, left: 0 }} 
-                />
-
+              <Legend verticalAlign='top' wrapperStyle={{ top: 0, left: 0 }} />
 
               <Line
-                type="monotone"
-                dataKey="yield"
-                name="수익률"
-                stroke="#000000"
+                type='monotone'
+                dataKey='yield'
+                name='수익률'
+                stroke='#000000'
                 dot={{ r: 4 }}
                 activeDot={{ r: 6 }}
               />
@@ -88,14 +80,14 @@ const RevenueStructure: React.FC<{ onOpenModal?: () => void }> = ({ onOpenModal 
         {onOpenModal && (
           <button
             onClick={onOpenModal}
-            className="mt-2 px-4 py-2 bg-mainGreen text-white rounded-md self-center"
+            className='p-2 h-9 w-full text-sm bg-grayBackground rounded-md hover:bg-mainGreen hover:text-white duration-100 ease-linear transition'
           >
             📊 크게 보기
           </button>
         )}
 
-          {/* 2) 버튼: flex-col 하단에, 가운데 정렬(self-center) + 위쪽 여백(mt-2) */}
-          {/* <button
+        {/* 2) 버튼: flex-col 하단에, 가운데 정렬(self-center) + 위쪽 여백(mt-2) */}
+        {/* <button
             onClick={onOpenModal}
             className="mt-2 px-4 py-2 bg-mainGreen text-white rounded-md self-center"
           >

--- a/frontend/src/pages/Dashboard/index.tsx
+++ b/frontend/src/pages/Dashboard/index.tsx
@@ -27,22 +27,22 @@ const Dashboard = () => {
 
           {/* 수익구조 분석 차트 */}
           <div className='col-span-4 row-start-3 row-end-5'>
-            <RevenueStructure onOpenModal={() => setIsRevenueModalOpen(true)}/>
-
+            <RevenueStructure onOpenModal={() => setIsRevenueModalOpen(true)} />
           </div>
 
           {/* 만기 상환 시나리오 */}
-          <div className="col-span-5 row-start-3 row-end-5">
+          <div className='col-span-5 row-start-3 row-end-5'>
             {/* onOpenModal을 넘겨주므로, 컴포넌트 안에 “크게 보기” 버튼이 표시됨 */}
-            <RepaymentScenario onOpenModal={() => setIsScenarioModalOpen(true)} />
+            <RepaymentScenario
+              onOpenModal={() => setIsScenarioModalOpen(true)}
+            />
           </div>
 
           {/* 이하 모달 렌더링 */}
           <Modal
             isOpen={isRevenueModalOpen}
             onClose={() => setIsRevenueModalOpen(false)}
-
-            >
+          >
             {/* 모달 안에서는 높이를 좀 더 키워서 렌더 */}
             <div style={{ width: '100%', height: 400 }}>
               <RevenueStructure />
@@ -52,13 +52,11 @@ const Dashboard = () => {
           <Modal
             isOpen={isScenarioModalOpen}
             onClose={() => setIsScenarioModalOpen(false)}
-
-            >
+          >
             <div style={{ width: '100%', height: 400 }}>
               <RepaymentScenario />
             </div>
           </Modal>
-
         </div>
       ) : (
         <div className='absolute left-[50%] top-[50%] transform translate-x-[-50%] translate-y-[-50%] w-full text-center text-grayBorder'>


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 수익구조, 만기 상환 차트 디자인 수정

## 📝 요구 사항과 구현 내용
<img width="300" alt="스크린샷 2025-06-04 오후 6 28 46" src="https://github.com/user-attachments/assets/264d581b-1f6e-47b2-abd4-b712e27095cf" />
<img width="400" alt="스크린샷 2025-06-04 오후 6 49 10" src="https://github.com/user-attachments/assets/aa6b2ffa-7298-4ec2-9d71-d7c3b0e76cd1" />


- 1920x1080 사이즈보다 작은 비율일 때 버튼이 차트 밖으로 나가는 현상 -> 오른쪽과 같이 수정
  - 화면 비율 조절할 때 그래프가 차트 밖으로 나가지 않도록 flex-1에 min-h-0도 함께 적용 후 그래프 높이 100%로 지정
  - flex-1이 잘 동작하도록 버튼 높이 고정
- hover 시에는 아래와 같음
<img width="400" alt="스크린샷 2025-06-04 오후 6 54 26" src="https://github.com/user-attachments/assets/44ae0322-5d95-4082-abd9-13f541d2c9b4" />

- 지수 차트 버튼에 애니메이션 적용

## 💬 PR 포인트 & 궁금한 점
- prettier 때문에 코드 많이 수정한 것처럼 보이는데 디자인만 수정했습니다!
- 오류 생기면 말씀해주세요:)